### PR TITLE
Fix: Correct phase check for dealer discard and ensure dealer picks u…

### DIFF
--- a/script.js
+++ b/script.js
@@ -125,7 +125,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function updateSelectedCardsDisplay() {
         // Visually indicate how many cards are selected vs needed for discard
-        if ((clientGameState.game_phase === 'maker_discard' || clientGameState.game_phase === 'maker_discard_one') &&
+        if ((clientGameState.game_phase === 'maker_discard' || clientGameState.game_phase === 'dealer_discard_one') &&
             clientGameState.current_player_turn === 0 && clientGameState.maker === 0) {
             const needed = clientGameState.cards_to_discard_count; // Should be 1 for discard_one, 5 for discard
             const selectedCount = selectedCardsForDiscard.length;


### PR DESCRIPTION
…p card

- Corrected an issue in `script.js` where the `dealer_discard_one` phase was incorrectly referred to as `maker_discard_one` in `updateSelectedCardsDisplay`. This prevented the discard button from enabling correctly when the dealer (human player) ordered up the up-card and needed to discard one card.
- Verified server-side logic in `euchre.py` correctly adds the up-card to the dealer's hand and transitions to the appropriate discard phase (`dealer_discard_one` for humans, internal handling for AI).