### PR TITLE
Fix: Ensure human dealer can discard when ordered up by AI

### DIFF
--- a/euchre.py
+++ b/euchre.py
@@ -357,6 +357,7 @@ def submit_action_api():
                 game_data["game_phase"] = "dealer_must_discard_after_order_up"
             current_message += f" {game_data['player_identities'][current_dealer_idx]} (Dealer) must discard 1 card."
             logging.info(f"Human Dealer P{current_dealer_idx} to discard 1. Phase: {game_data['game_phase']}. Maker: P{game_data['maker']}.")
+            game_data["message"] = current_message # Update message here for human dealer
 
         else: # AI Dealer
             logging.info(f"AI Dealer P{current_dealer_idx} ({game_data['player_identities'][current_dealer_idx]}) must discard 1. Maker: P{game_data['maker']}. Trump: {game_data['trump_suit']}.")


### PR DESCRIPTION
When an AI player orders up the up-card and the human player (P0) is the dealer, the game state was not updating correctly to prompt the human dealer to discard. This change ensures that the `game_data['message']` is updated immediately within the human dealer's logic block in the `order_up` action, allowing the UI to reflect the correct state and enable the discard action.