### PR TITLE
Fix: Ensure Card objects in played_cards_this_round are serialized

### DIFF
--- a/euchre.py
+++ b/euchre.py
@@ -1870,6 +1870,8 @@ def game_data_to_json(current_game_data_arg): # Renamed arg for clarity
     if json_safe_data.get('trick_cards'): json_safe_data['trick_cards'] = [{'player': tc['player'], 'card': tc['card'].to_dict()} for tc in json_safe_data['trick_cards']]
     if json_safe_data.get('last_completed_trick') and json_safe_data['last_completed_trick'].get('played_cards'):
         json_safe_data['last_completed_trick']['played_cards'] = [{'player': pc['player'], 'card': pc['card'].to_dict() if isinstance(pc['card'], Card) else pc['card']} for pc in json_safe_data['last_completed_trick']['played_cards']]
+    if json_safe_data.get('played_cards_this_round'):
+        json_safe_data['played_cards_this_round'] = [card.to_dict() for card in json_safe_data['played_cards_this_round']]
     return json_safe_data
 
 if __name__ == "__main__":


### PR DESCRIPTION
The jsonify function was encountering raw Card objects because the `played_cards_this_round` list within the game_data was not being converted to a JSON-serializable format.

This commit updates the `game_data_to_json` function to iterate through `played_cards_this_round` and convert each Card object to its dictionary representation using the existing `to_dict()` method.